### PR TITLE
Update giantswarm/install-binary-action to v4.1.0

### DIFF
--- a/.github/workflows/validate-sync-diffs.yaml
+++ b/.github/workflows/validate-sync-diffs.yaml
@@ -14,7 +14,7 @@ jobs:
           fetch-depth: 1
 
       - name: Download vendir
-        uses: giantswarm/install-binary-action@e2730babbc89f02ef1559b042d33cbe24f5c3547 # v4.0.2
+        uses: giantswarm/install-binary-action@5bef88f65012037dd836117c8d344b21bb559854 # v4.1.0
         with:
           binary: "vendir"
           version: "0.45.0"
@@ -22,7 +22,7 @@ jobs:
           smoke_test: "${binary} --version"
 
       - name: Download jq
-        uses: giantswarm/install-binary-action@e2730babbc89f02ef1559b042d33cbe24f5c3547 # v4.0.2
+        uses: giantswarm/install-binary-action@5bef88f65012037dd836117c8d344b21bb559854 # v4.1.0
         with:
           binary: "jq"
           version: "jq-1.8.1"


### PR DESCRIPTION
This PR updates `giantswarm/install-binary-action` to v4.1.0, fixing an issue where downloaded binaries fail to execute.

See https://github.com/giantswarm/github/pull/5228 for context.